### PR TITLE
Fixed invalid path

### DIFF
--- a/create-keys.sh
+++ b/create-keys.sh
@@ -4,9 +4,9 @@
 # A simple OpenSSL script to create self signed client encryption public and private keys
 #########################################################################################
 
-rm -rf keys2
-mkdir -p keys2
-cd keys2
+rm -rf keys
+mkdir -p keys
+cd keys
 set -e
 
 #


### PR DESCRIPTION
I noticed when doing some crypto stuff that there was an invalid path of 'keys2' in this repo - must have been an accidental checkin. I have fixed it in this small PR.